### PR TITLE
Centralize model CRUD onto a single BaseModel

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,32 @@
+from config import db
+
+
+class BaseModel(db.Model):
+  #__abstract__ keeps SQLAlchemy from mapping BaseModel to its own table;
+  #it only provides shared CRUD behavior to the models that inherit it.
+  __abstract__ = True
+
+  #fields a client may change via update_db. Empty by default so a model is
+  #closed to mass-assignment until it deliberately opts fields in.
+  updatable_fields = set()
+
+  def save_db(self):
+    db.session.add(self)
+    db.session.commit()
+
+  def delete_db(self):
+    db.session.delete(self)
+    db.session.commit()
+
+  def update_db(self, new_values):
+    #Only whitelisted keys are written, and only when the value actually
+    #differs. The set of changed fields is returned so a handler can tell a
+    #real update from a no-op (the root cause behind issue #9's misleading 200s).
+    changed = set()
+    for key, value in new_values.items():
+      if key in self.updatable_fields and getattr(self, key) != value:
+        setattr(self, key, value)
+        changed.add(key)
+    if changed:
+      db.session.commit()
+    return changed

--- a/models/cart.py
+++ b/models/cart.py
@@ -1,8 +1,9 @@
 from config import db
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
 
-class Cart(db.Model):
+class Cart(BaseModel):
   __tablename__ = 'carts'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -24,17 +25,3 @@ class Cart(db.Model):
     cart = cls(user=user, product=product, quantity= quantity)
     cart.save_db()
     return cart
-
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      if key in self.updatable_fields:
-        setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/classification.py
+++ b/models/classification.py
@@ -1,13 +1,17 @@
 from sqlalchemy.orm import validates
 from config import db
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
 
-class Classification(db.Model):
+class Classification(BaseModel):
   __tablename__ = 'classifications'
 
   id = db.Column(db.Integer, primary_key=True)
   classification = db.Column(db.String, nullable=False)
+
+  #fields a client may change via update_db
+  updatable_fields = {'classification'}
 
   #relationships
   
@@ -47,17 +51,3 @@ class Classification(db.Model):
     classification = cls(classification=classification)
     classification.save_db()
     return classification
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()
-    

--- a/models/illness.py
+++ b/models/illness.py
@@ -1,14 +1,18 @@
 from config import db
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
-class Illness(db.Model):
+class Illness(BaseModel):
   __tablename__ = 'illnesses'
 
   id = db.Column(db.Integer, primary_key=True)
   name = db.Column(db.String, nullable=False)
   description = db.Column(db.String, nullable=False)
   remedy = db.Column(db.String)
+
+  #fields a client may change via update_db
+  updatable_fields = {'name', 'description', 'remedy'}
 
   #relationship with illnesses table
   illness_symptom = db.relationship('IllnessSymptom', back_populates='illness', cascade="all, delete-orphan")
@@ -39,16 +43,3 @@ class Illness(db.Model):
     illness = cls(name=name, description=description, remedy=remedy )
     illness.save_db()
     return illness
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/illnessclassification.py
+++ b/models/illnessclassification.py
@@ -1,9 +1,10 @@
 from config import db
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
 
-class IllnessClassification(db.Model):
+class IllnessClassification(BaseModel):
   __tablename__ = 'illnessesclassifications'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -18,16 +19,3 @@ class IllnessClassification(db.Model):
     illness_classification = cls(illness=illness, classification=classification)
     illness_classification.save_db()
     return illness_classification
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/illnessmedication.py
+++ b/models/illnessmedication.py
@@ -1,7 +1,8 @@
 from sqlalchemy import ForeignKey
 from config import db
+from .base import BaseModel
 
-class IllnessMedication(db.Model):
+class IllnessMedication(BaseModel):
   __tablename__ = 'illnessesmedications'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -17,16 +18,3 @@ class IllnessMedication(db.Model):
     illness_symptom = cls(illness=illness, medication=medication)
     illness_symptom.save_db()
     return illness_symptom
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/illnessproduct.py
+++ b/models/illnessproduct.py
@@ -1,6 +1,7 @@
 from config import db
+from .base import BaseModel
 
-class IllnessProduct(db.Model):
+class IllnessProduct(BaseModel):
   __tablename__ = 'illnessesproducts'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -17,16 +18,3 @@ class IllnessProduct(db.Model):
     illness_product = cls(illness=illness, product=product)
     illness_product.save_db()
     return illness_product
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/illnesssymptom.py
+++ b/models/illnesssymptom.py
@@ -2,9 +2,10 @@ from sqlalchemy import Nullable
 from config import db
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
 
-class IllnessSymptom(db.Model):
+class IllnessSymptom(BaseModel):
   __tablename__ = 'illnessessymptoms'
 
   id = db.Column(db.Integer, primary_key=True, nullable=False)
@@ -20,17 +21,4 @@ class IllnessSymptom(db.Model):
     illness_symptom = cls(illness=illness, symptom=symptom)
     illness_symptom.save_db()
     return illness_symptom
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()
 

--- a/models/medication.py
+++ b/models/medication.py
@@ -1,6 +1,7 @@
 from config import db
+from .base import BaseModel
 
-class Medication(db.Model):
+class Medication(BaseModel):
   __tablename__ = 'medications'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -10,22 +11,12 @@ class Medication(db.Model):
   #relationships
   #relationship with illnessmedication
   illness_medication = db.relationship('IllnessMedication', back_populates = 'medication', cascade='all, delete-orphan')
-  
+
+  #fields a client may change via update_db
+  updatable_fields = {'name', 'description'}
+
   @classmethod
   def create_row(cls, name, description):
     pet = cls(name=name, description=description)
     pet.save_db()
     return pet
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/pet.py
+++ b/models/pet.py
@@ -1,8 +1,9 @@
 from sqlalchemy.orm import validates
 from config import db
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
-class Pet(db.Model):
+class Pet(BaseModel):
   __tablename__ = 'pets'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -32,17 +33,3 @@ class Pet(db.Model):
     pet = cls(name=name, age=age, weight=weight, species_id=species, user_id=user)
     pet.save_db()
     return pet
-
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      if key in self.updatable_fields:
-        setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/petsymptom.py
+++ b/models/petsymptom.py
@@ -1,9 +1,10 @@
 from sqlalchemy.orm import validates
 from config import db
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
 
-class PetSymptom(db.Model):
+class PetSymptom(BaseModel):
   __tablename__ = 'petsymptoms'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -22,16 +23,3 @@ class PetSymptom(db.Model):
     pet_symptom = cls(pet=pet, symptom=symptom)
     pet_symptom.save_db()
     return pet_symptom
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/product.py
+++ b/models/product.py
@@ -1,6 +1,7 @@
 from config import db
+from .base import BaseModel
 
-class Product(db.Model):
+class Product(BaseModel):
   __tablename__='products'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -13,23 +14,13 @@ class Product(db.Model):
   carts = db.relationship('Cart', back_populates='product')
 
   illness_product = db.relationship('IllnessProduct', back_populates='product')
-  
+
+  #fields a client may change via update_db; never id or relationships
+  updatable_fields = {'name', 'price', 'description', 'prescription'}
+
   #methods to communicate with database
   @classmethod
   def create_row(cls, name, price, description, prescription):
     product = cls(name=name, price=price, description=description, prescription=prescription)
     product.save_db()
     return product
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/species.py
+++ b/models/species.py
@@ -2,9 +2,10 @@
 from sqlalchemy.orm import validates
 from config import db
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
 
-class Species(db.Model):
+class Species(BaseModel):
   __tablename__ = 'species'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -12,6 +13,9 @@ class Species(db.Model):
 
   #relationships
   species_classification = db.relationship('SpeciesClassification', back_populates='species')
+
+  #fields a client may change via update_db
+  updatable_fields = {'type_name'}
 
   #hybrid_property is being used for the getter and setter 
   #because classification and species attributes are NOT columns
@@ -40,16 +44,3 @@ class Species(db.Model):
     type_name_obj = cls(type_name=type_name)
     type_name_obj.save_db()
     return type_name_obj
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/speciesclassification.py
+++ b/models/speciesclassification.py
@@ -1,8 +1,9 @@
 from config import db
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
-class SpeciesClassification(db.Model):
+class SpeciesClassification(BaseModel):
   __tablename__ = 'speciesclassifications'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -59,17 +60,4 @@ class SpeciesClassification(db.Model):
     species_classification = cls(classification=classification, species=species)
     species_classification.save_db()
     return species_classification
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
 
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()
-    

--- a/models/symptom.py
+++ b/models/symptom.py
@@ -1,13 +1,17 @@
 from config import db
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
-class Symptom(db.Model):
+class Symptom(BaseModel):
   __tablename__ = 'symptoms'
 
   id = db.Column(db.Integer, primary_key=True)
   name = db.Column(db.String, nullable=False)
-  
+
+  #fields a client may change via update_db
+  updatable_fields = {'name'}
+
   #relationship with classifications table
   symptom_classifications = db.relationship('SymptomClassification', back_populates='symptom')
   
@@ -40,16 +44,3 @@ class Symptom(db.Model):
     name = cls(name = name)
     name.save_db()
     return name
-  
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/symptomsclassifications.py
+++ b/models/symptomsclassifications.py
@@ -1,8 +1,9 @@
 from config import db
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.hybrid import hybrid_property
+from .base import BaseModel
 
-class SymptomClassification(db.Model):
+class SymptomClassification(BaseModel):
   __tablename__ = 'symptomsclassifications'
 
   id = db.Column(db.Integer, primary_key=True)
@@ -54,16 +55,3 @@ class SymptomClassification(db.Model):
     symptomclassification = cls(classification = classification_inst, symptom= symptom_inst)
     symptomclassification.save_db()
     return symptomclassification
-
-  def save_db(self):
-    db.session.add(self)
-    db.session.commit()
-
-  def update_db(self, new_values):
-    for key, value in new_values.items():
-      setattr(self, key, value)
-    db.session.commit()
-
-  def delete_db(self):
-    db.session.delete(self)
-    db.session.commit()

--- a/models/user.py
+++ b/models/user.py
@@ -4,9 +4,10 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from config import db, bcrypt
+from .base import BaseModel
 
-class User(db.Model):
-  
+class User(BaseModel):
+
   __tablename__ = 'users'
 
   __table_args__ = (db.CheckConstraint('length(name) > 3', name='ck_user_name_length'),)
@@ -16,6 +17,11 @@ class User(db.Model):
   username = db.Column(db.String, nullable=False, unique=True)
   email = db.Column(db.String, nullable=False, unique=True)
   _password_hash = db.Column(db.String, nullable=False)
+
+  #fields a client may change via update_db. Deliberately excludes id,
+  #username (login identity), and _password_hash (set only via password_hash
+  #setter). Password changes must not go through mass-assignment.
+  updatable_fields = {'name', 'email'}
 
   #relationships
   carts = db.relationship('Cart', back_populates='user')

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,16 @@
+# Lessons
+
+## Commit granularity and message style
+
+**Correction (2026-06-17):** On issue #10 the work was squashed into one commit of 17 files. Commits should be made incrementally as the work progresses, not batched at the end. A dispatched agent also failed to commit because it was blocked on tooling; the commit rule must be passed into agent dispatch prompts, since subagents do not inherit it.
+
+**Rules:**
+- Commit one logical step at a time, as each step completes. Do not bundle an entire multi-part issue into a single commit. Each commit should leave the code in a working/importable state.
+- For a multi-part issue, the natural seams are separate commits (e.g. "add the base abstraction" then "migrate callers onto it"), as long as each is self-consistent.
+- Match the existing log's message style:
+  - Imperative mood, capitalized first word, no trailing period.
+  - Concise subject (~50-72 chars). Add a short "why" clause when it clarifies intent.
+  - No conventional-commit prefixes (no `feat:`, `fix:`).
+  - No issue number in the subject line. Reference the issue in the PR body, not the commit subject.
+  - Examples from the log: "Drop stale comment about the old _password_hash validator", "Guard login against a missing body or credentials to avoid a 500", "Rename ic to illness_classification for readability".
+- When dispatching an agent to implement, include these commit rules in its prompt.


### PR DESCRIPTION
Closes #10.

## What
Every model reimplemented identical `save_db` / `update_db` / `delete_db` helpers (~16 duplications). This introduces one abstract base, `models/base.py::BaseModel` (`__abstract__ = True`), that owns CRUD once. All 16 models now inherit from it and drop their duplicated methods.

Built as three reviewable commits:
1. Add the abstract BaseModel (no callers yet).
2. Move entity models onto it and declare their field whitelists.
3. Move the association tables onto it (they inherit the empty default).

## How it addresses each part of the issue
- **Single central base for CRUD:** `BaseModel` defines `save_db`, `delete_db`, `update_db` once.
- **Report what changed on update:** `update_db(new_values)` returns the set of fields it actually wrote, and skips no-op (same-value) writes. This is the model-layer groundwork behind issue #9's misleading `200`s.
- **Mass-assignment hardening:** `update_db` only writes keys in a per-model `updatable_fields` whitelist. The base default is `set()`, so a model is closed to client writes until it deliberately opts fields in.

## Per-model `updatable_fields`
| Model | whitelist |
|---|---|
| product | name, price, description, prescription |
| illness | name, description, remedy |
| medication | name, description |
| classification | classification |
| species | type_name |
| symptom | name |
| user | name, email (never id, username, or _password_hash) |
| cart | quantity (unchanged) |
| pet | name, age, weight (unchanged) |
| all association tables | empty (inherit default; they hold only foreign keys) |

`create_row` is intentionally left per-model since signatures genuinely differ.

## Scope note
`update_db` now exposes the changed-field set, but the route handlers are **not** changed in this PR, so issue #9's misleading `200`s are not yet closed end-to-end. That route-level change belongs to #9; this PR is the model-layer foundation it depends on.

## Verification
- `from models.models import *` imports all 16 models cleanly; `BaseModel.__table__` confirmed absent (stays abstract, all subclasses map).
- Reviewed across three independent passes (correctness, security, simplicity): no code changes required. Whitelists confirmed against real columns; no privilege/identity field reachable via `update_db`; no over-engineering.