### PR TITLE
test: set up test framework and shared fixtures

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,5 +24,9 @@ flask-wtf = "*"
 flask-limiter = "*"
 redis = "*"
 
+[dev-packages]
+pytest = "*"
+pytest-flask = "*"
+
 [requires]
 python_full_version = "3.8.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48d8a6285374b6b825a5837124b85bf18cff25e64d5668bae08020f6d31e5686"
+            "sha256": "ae153e0fb89bc014bf04570461396589ad101df89565edd53e4157dd8ba45d1f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1014,5 +1014,241 @@
             "version": "==3.20.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "click": {
+            "hashes": [
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.8"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219",
+                "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.3.1"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf",
+                "sha256:edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.2.5"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==8.5.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.6"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
+                "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
+                "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
+                "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
+                "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
+                "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
+                "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
+                "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
+                "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
+                "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
+                "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
+                "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
+                "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
+                "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
+                "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
+                "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
+                "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
+                "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
+                "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
+                "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
+                "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
+                "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
+                "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
+                "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
+                "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
+                "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
+                "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
+                "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
+                "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
+                "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
+                "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
+                "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
+                "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
+                "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
+                "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
+                "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
+                "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
+                "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
+                "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
+                "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
+                "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
+                "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
+                "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
+                "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
+                "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
+                "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
+                "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
+                "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
+                "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+                "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
+                "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
+                "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
+                "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
+                "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
+                "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
+                "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
+                "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
+                "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
+                "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
+                "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.5"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
+                "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.5"
+        },
+        "pytest-flask": {
+            "hashes": [
+                "sha256:58be1c97b21ba3c4d47e0a7691eb41007748506c36bf51004f78df10691fa95e",
+                "sha256:c0e36e6b0fddc3b91c4362661db83fa694d1feb91fa505475be6732b5bc8c253"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853",
+                "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe",
+                "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5",
+                "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d",
+                "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd",
+                "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26",
+                "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54",
+                "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6",
+                "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c",
+                "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a",
+                "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd",
+                "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f",
+                "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5",
+                "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9",
+                "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662",
+                "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9",
+                "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1",
+                "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585",
+                "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e",
+                "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c",
+                "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41",
+                "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f",
+                "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085",
+                "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15",
+                "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7",
+                "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c",
+                "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36",
+                "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076",
+                "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac",
+                "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8",
+                "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232",
+                "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece",
+                "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a",
+                "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897",
+                "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d",
+                "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4",
+                "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917",
+                "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396",
+                "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a",
+                "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc",
+                "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba",
+                "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f",
+                "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257",
+                "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30",
+                "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf",
+                "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9",
+                "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049"
+            ],
+            "markers": "python_version < '3.11' and python_version >= '3.7'",
+            "version": "==2.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
+                "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.13.2"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f",
+                "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.2.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
+                "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.20.2"
+        }
+    }
 }

--- a/conftest.py
+++ b/conftest.py
@@ -26,3 +26,21 @@ def app():
     yield flask_app
     db.session.remove()
     db.drop_all()
+
+
+@pytest.fixture(scope='function')
+def db_session(app):
+  # Bind the session to a single connection-level transaction so every test
+  # runs in isolation. Rolling back after the test discards all of its writes,
+  # preventing state from leaking into other tests.
+  connection = db.engine.connect()
+  transaction = connection.begin()
+
+  db.session.configure(bind=connection)
+
+  yield db.session
+
+  db.session.remove()
+  transaction.rollback()
+  connection.close()
+  db.session.configure(bind=db.engine)

--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,11 @@ def app():
 
   flask_app.config['SQLALCHEMY_DATABASE_URI'] = test_uri
   flask_app.config['TESTING'] = True
+  # Disable the rate limiter for the whole suite. auth_client is function scoped,
+  # so it logs in once per test, and POST /login is capped at 5/min, 20/hour. Left
+  # enabled, the suite would trip 429 Too Many Requests and produce flaky failures
+  # unrelated to the code under test. The tradeoff is that the limiter itself goes
+  # uncovered here, so it needs a dedicated test that re-enables it locally.
   flask_app.config['RATELIMIT_ENABLED'] = False
   flask_app.config['SESSION_COOKIE_SECURE'] = False
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,11 @@ import pytest
 # USER/PASSWORD env vars the app uses are available here.
 from config import app as flask_app, db
 
+# Importing the app module wires up everything the real server does: it registers
+# all models on db.metadata (so db.create_all() builds the full schema), mounts
+# every route, and installs the auth before_request hook and CSRF error handler.
+import app as _app_module  # noqa: F401
+
 
 @pytest.fixture(scope='session')
 def app():

--- a/conftest.py
+++ b/conftest.py
@@ -49,3 +49,18 @@ def db_session(app):
 @pytest.fixture(scope='function')
 def client(app):
   return app.test_client()
+
+
+@pytest.fixture(scope='function')
+def test_user(db_session):
+  from models.models import User
+
+  user = User(
+    name='John Smith',
+    username='jsmith',
+    email='jsmith@email.com',
+  )
+  user.password_hash = 'testpassword123'
+  db_session.add(user)
+  db_session.commit()
+  return user

--- a/conftest.py
+++ b/conftest.py
@@ -64,3 +64,9 @@ def test_user(db_session):
   db_session.add(user)
   db_session.commit()
   return user
+
+
+@pytest.fixture(scope='function')
+def csrf_token(client):
+  response = client.get('/csrf-token')
+  return response.get_json()['csrf_token']

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,13 @@ from config import app as flask_app, db
 # Importing the app module wires up everything the real server does: it registers
 # all models on db.metadata (so db.create_all() builds the full schema), mounts
 # every route, and installs the auth before_request hook and CSRF error handler.
-import app as _app_module  # noqa: F401
+import app as _app_module
+
+# Single source of truth for the test login. test_user inserts this user and
+# auth_client logs in with these same credentials. Keeping them here avoids
+# duplicating the literals across fixtures where a typo would silently break login.
+TEST_USERNAME = 'jsmith'
+TEST_PASSWORD = 'testpassword123'
 
 
 @pytest.fixture(scope='session')
@@ -74,10 +80,10 @@ def test_user(db_session):
 
   user = User(
     name='John Smith',
-    username='jsmith',
+    username=TEST_USERNAME,
     email='jsmith@email.com',
   )
-  user.password_hash = 'testpassword123'
+  user.password_hash = TEST_PASSWORD
   db_session.add(user)
   db_session.commit()
   return user
@@ -93,7 +99,7 @@ def csrf_token(client):
 def auth_client(client, test_user, csrf_token):
   client.post(
     '/login',
-    json={'username': 'jsmith', 'password': 'testpassword123'},
+    json={'username': TEST_USERNAME, 'password': TEST_PASSWORD},
     headers={'X-CSRFToken': csrf_token},
   )
   return client

--- a/conftest.py
+++ b/conftest.py
@@ -70,3 +70,13 @@ def test_user(db_session):
 def csrf_token(client):
   response = client.get('/csrf-token')
   return response.get_json()['csrf_token']
+
+
+@pytest.fixture(scope='function')
+def auth_client(client, test_user, csrf_token):
+  client.post(
+    '/login',
+    json={'username': 'jsmith', 'password': 'testpassword123'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  return client

--- a/conftest.py
+++ b/conftest.py
@@ -35,20 +35,32 @@ def app():
 
 @pytest.fixture(scope='function')
 def db_session(app):
-  # Bind the session to a single connection-level transaction so every test
-  # runs in isolation. Rolling back after the test discards all of its writes,
-  # preventing state from leaking into other tests.
-  connection = db.engine.connect()
+  # Run every test inside one connection-level transaction that is rolled back
+  # at teardown, so no test's writes leak into another.
+  #
+  # Flask-SQLAlchemy's Session.get_bind always resolves ORM queries to
+  # db.engines[None] and ignores the session's own bind, so binding the session
+  # to a connection does nothing on its own. We swap db.engines[None] to point
+  # at our single connection for the duration of the test, and set
+  # join_transaction_mode='create_savepoint' so a test's commit() releases a
+  # SAVEPOINT instead of committing the real transaction. The outer rollback
+  # then discards everything.
+  engines = db.engines
+  original_engine = engines[None]
+  connection = original_engine.connect()
   transaction = connection.begin()
 
-  db.session.configure(bind=connection)
+  engines[None] = connection
+  db.session.remove()
+  db.session.configure(join_transaction_mode='create_savepoint')
 
   yield db.session
 
   db.session.remove()
+  db.session.configure(join_transaction_mode='conditional_savepoint')
+  engines[None] = original_engine
   transaction.rollback()
   connection.close()
-  db.session.configure(bind=db.engine)
 
 
 @pytest.fixture(scope='function')

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,28 @@
+import os
+
+import pytest
+
+# Importing config triggers Pipenv's automatic .env loading so the same
+# USER/PASSWORD env vars the app uses are available here.
+from config import app as flask_app, db
+
+
+@pytest.fixture(scope='session')
+def app():
+  user = os.getenv('USER')
+  password = os.getenv('PASSWORD')
+  default_test_uri = (
+    f'postgresql://{user}:{password}@localhost:5432/animalsmd_test'
+  )
+  test_uri = os.getenv('TEST_DATABASE_URL', default_test_uri)
+
+  flask_app.config['SQLALCHEMY_DATABASE_URI'] = test_uri
+  flask_app.config['TESTING'] = True
+  flask_app.config['RATELIMIT_ENABLED'] = False
+  flask_app.config['SESSION_COOKIE_SECURE'] = False
+
+  with flask_app.app_context():
+    db.create_all()
+    yield flask_app
+    db.session.remove()
+    db.drop_all()

--- a/conftest.py
+++ b/conftest.py
@@ -44,3 +44,8 @@ def db_session(app):
   transaction.rollback()
   connection.close()
   db.session.configure(bind=db.engine)
+
+
+@pytest.fixture(scope='function')
+def client(app):
+  return app.test_client()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,9 @@
+def test_framework_and_auth_smoke(client, auth_client):
+  # The CSRF endpoint is public and must hand back a usable token.
+  csrf_response = client.get('/csrf-token')
+  assert csrf_response.status_code == 200
+  assert csrf_response.get_json()['csrf_token']
+
+  # A logged-in client must reach a protected endpoint successfully.
+  protected_response = auth_client.get('/check_session')
+  assert protected_response.status_code == 200


### PR DESCRIPTION
Closes #13.

Sets up the pytest scaffolding that the endpoint-test issues depend on: a test client, an isolated Postgres test database, and reusable login + CSRF fixtures, plus one smoke test.

## What this adds
- `pytest` + `pytest-flask` dev dependencies and `pytest.ini` (test discovery).
- `conftest.py` fixtures:
  - `app` (session): points tests at a separate `animalsmd_test` database, enables TESTING, disables rate limiting, runs create_all/drop_all.
  - `db_session` (function): per-test transaction rollback so no test's writes leak into another.
  - `client`, `test_user` (jsmith), `csrf_token`, and `auth_client` (logged-in client) fixtures.
- `tests/test_smoke.py`: one smoke test covering csrf token fetch, login, session, and a protected endpoint.
