### PR TITLE
test: add functional tests for auth and session endpoints

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -44,6 +44,21 @@ def app():
     db.drop_all()
 
 
+@pytest.fixture(scope='function', autouse=True)
+def app_context(app):
+  # Push a fresh application context per test so Flask's `g` starts empty each
+  # time. The session-scoped `app` fixture keeps one long-lived context open for
+  # create_all/drop_all, and `g` is bound to the application context, so without
+  # a per-test context every test would share the same `g`. flask_wtf's
+  # generate_csrf caches its token in `g` and only writes the matching value to
+  # the session when it is absent; a leaked `g.csrf_token` makes the second test
+  # onward skip that session write, emit no session cookie, and fail CSRF
+  # validation on the next mutating request. A nested context gives each test its
+  # own `g` and is popped at teardown.
+  with app.app_context():
+    yield
+
+
 @pytest.fixture(scope='function')
 def db_session(app):
   # Run every test inside one connection-level transaction that is rolled back

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 # Importing config triggers Pipenv's automatic .env loading so the same
 # USER/PASSWORD env vars the app uses are available here.
-from config import app as flask_app, db
+from config import app as flask_app, db, limiter
 
 # Importing the app module wires up everything the real server does: it registers
 # all models on db.metadata (so db.create_all() builds the full schema), mounts
@@ -34,7 +34,13 @@ def app():
   # enabled, the suite would trip 429 Too Many Requests and produce flaky failures
   # unrelated to the code under test. The tradeoff is that the limiter itself goes
   # uncovered here, so it needs a dedicated test that re-enables it locally.
+  #
+  # Flask-Limiter caches its enabled flag from RATELIMIT_ENABLED at construction
+  # time, which happens on import in config.py before this fixture runs, so
+  # setting the config key alone has no effect. Set limiter.enabled directly so
+  # the limit decorators become no-ops for the suite.
   flask_app.config['RATELIMIT_ENABLED'] = False
+  limiter.enabled = False
   flask_app.config['SESSION_COOKIE_SECURE'] = False
 
   with flask_app.app_context():

--- a/tests/test_check_session.py
+++ b/tests/test_check_session.py
@@ -8,3 +8,10 @@ def test_check_session_authenticated_returns_200(auth_client):
   body = response.get_json()
   assert body['username'] == TEST_USERNAME
   assert 'password' not in body
+
+
+def test_check_session_unauthenticated_returns_401(client):
+  # A client with no session is told it is not logged in.
+  response = client.get('/check_session')
+  assert response.status_code == 401
+  assert response.get_json() == {'error': 'Not logged in'}

--- a/tests/test_check_session.py
+++ b/tests/test_check_session.py
@@ -1,0 +1,10 @@
+from conftest import TEST_USERNAME
+
+
+def test_check_session_authenticated_returns_200(auth_client):
+  # A logged-in client gets its own user JSON back from the session check.
+  response = auth_client.get('/check_session')
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['username'] == TEST_USERNAME
+  assert 'password' not in body

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,8 @@
+def test_csrf_token_returns_usable_token(client):
+  # The CSRF endpoint is public and must hand back a non-empty token string
+  # that mutating requests can then echo back in the X-CSRFToken header.
+  response = client.get('/csrf-token')
+  assert response.status_code == 200
+  token = response.get_json()['csrf_token']
+  assert isinstance(token, str)
+  assert token

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,15 @@
+from conftest import TEST_USERNAME, TEST_PASSWORD
+
+
+def test_login_valid_credentials_returns_200(client, test_user, csrf_token):
+  # Correct username and password log the user in and return their JSON, without
+  # ever echoing the password back.
+  response = client.post(
+    '/login',
+    json={'username': TEST_USERNAME, 'password': TEST_PASSWORD},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['username'] == TEST_USERNAME
+  assert 'password' not in body

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -13,3 +13,15 @@ def test_login_valid_credentials_returns_200(client, test_user, csrf_token):
   body = response.get_json()
   assert body['username'] == TEST_USERNAME
   assert 'password' not in body
+
+
+def test_login_wrong_password_returns_401(client, test_user, csrf_token):
+  # A real username with the wrong password is rejected with the same generic
+  # message used for unknown users, so usernames cannot be enumerated.
+  response = client.post(
+    '/login',
+    json={'username': TEST_USERNAME, 'password': 'wrongpassword'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 401
+  assert response.get_json() == {'error': 'Invalid Credentials'}

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -25,3 +25,15 @@ def test_login_wrong_password_returns_401(client, test_user, csrf_token):
   )
   assert response.status_code == 401
   assert response.get_json() == {'error': 'Invalid Credentials'}
+
+
+def test_login_missing_credentials_returns_401(client, csrf_token):
+  # A body that omits the password short-circuits to the same generic rejection
+  # before any user lookup happens.
+  response = client.post(
+    '/login',
+    json={'username': TEST_USERNAME},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 401
+  assert response.get_json() == {'error': 'Invalid Credentials'}

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,0 +1,9 @@
+def test_logout_when_logged_in_returns_200(auth_client, csrf_token):
+  # A logged-in session can log out; the route clears user_id and returns an
+  # empty body with 200.
+  response = auth_client.delete(
+    '/logout',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  assert response.get_json() == {}

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -7,3 +7,14 @@ def test_logout_when_logged_in_returns_200(auth_client, csrf_token):
   )
   assert response.status_code == 200
   assert response.get_json() == {}
+
+
+def test_logout_when_not_logged_in_returns_401(client, csrf_token):
+  # With no user_id in the session there is nothing to log out, so the route
+  # rejects the request with 401.
+  response = client.delete(
+    '/logout',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 401
+  assert response.get_json() == {'error': 'not logged in'}

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -79,3 +79,20 @@ def test_signup_invalid_name_returns_422(client, db_session, csrf_token):
   assert response.get_json() == {
     'error': 'Name must be of type string and more than 3 characters'
   }
+
+
+def test_signup_invalid_email_returns_422(client, db_session, csrf_token):
+  # The email validator rejects any value without an '@'; the resulting
+  # ValueError is reported as a 422 with the validator's message.
+  response = client.post(
+    '/signup',
+    json={
+      'name': 'Jane Doe',
+      'username': 'janedoe',
+      'email': 'not-an-email',
+      'password': 'supersecret',
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 422
+  assert response.get_json() == {'error': 'Email must be an email address'}

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,18 @@
+def test_signup_happy_path_returns_201(client, db_session, csrf_token):
+  # A valid payload creates the user, returns 201 with the user JSON, and never
+  # leaks the password back to the caller.
+  response = client.post(
+    '/signup',
+    json={
+      'name': 'Jane Doe',
+      'username': 'janedoe',
+      'email': 'janedoe@email.com',
+      'password': 'supersecret',
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 201
+  body = response.get_json()
+  assert body['username'] == 'janedoe'
+  assert body['email'] == 'janedoe@email.com'
+  assert 'password' not in body

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -43,3 +43,20 @@ def test_signup_missing_fields_returns_400(client, csrf_token):
   assert 'name' in error
   assert 'email' in error
   assert 'password' in error
+
+
+def test_signup_duplicate_user_returns_422(client, test_user, csrf_token):
+  # Reusing an existing username trips the unique constraint, which the route
+  # catches as an IntegrityError and reports as Unprocessable Entity.
+  response = client.post(
+    '/signup',
+    json={
+      'name': 'Impostor Smith',
+      'username': 'jsmith',
+      'email': 'different@email.com',
+      'password': 'supersecret',
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 422
+  assert response.get_json() == {'error': 'Unproccessable Entity'}

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -96,3 +96,23 @@ def test_signup_invalid_email_returns_422(client, db_session, csrf_token):
   )
   assert response.status_code == 422
   assert response.get_json() == {'error': 'Email must be an email address'}
+
+
+def test_signup_invalid_password_returns_422(client, db_session, csrf_token):
+  # The password setter requires a string of at least eight characters; a short
+  # password raises ValueError, surfaced as a 422 with that message. The field is
+  # non-empty so it clears the route's required-fields check first.
+  response = client.post(
+    '/signup',
+    json={
+      'name': 'Jane Doe',
+      'username': 'janedoe',
+      'email': 'janedoe@email.com',
+      'password': 'short',
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 422
+  assert response.get_json() == {
+    'error': 'password must be at least 8 characters long'
+  }

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -16,3 +16,14 @@ def test_signup_happy_path_returns_201(client, db_session, csrf_token):
   assert body['username'] == 'janedoe'
   assert body['email'] == 'janedoe@email.com'
   assert 'password' not in body
+
+
+def test_signup_empty_body_returns_400(client, csrf_token):
+  # With no JSON body the route rejects the request before touching the model.
+  response = client.post(
+    '/signup',
+    json={},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'Request body is required'}

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -27,3 +27,19 @@ def test_signup_empty_body_returns_400(client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'Request body is required'}
+
+
+def test_signup_missing_fields_returns_400(client, csrf_token):
+  # A present but incomplete body is reported with the names of the fields that
+  # are missing, before any model validation runs.
+  response = client.post(
+    '/signup',
+    json={'username': 'janedoe'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  error = response.get_json()['error']
+  assert error.startswith('Missing required fields:')
+  assert 'name' in error
+  assert 'email' in error
+  assert 'password' in error

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -60,3 +60,22 @@ def test_signup_duplicate_user_returns_422(client, test_user, csrf_token):
   )
   assert response.status_code == 422
   assert response.get_json() == {'error': 'Unproccessable Entity'}
+
+
+def test_signup_invalid_name_returns_422(client, db_session, csrf_token):
+  # The name validator requires a string longer than three characters; a short
+  # name raises ValueError, which the route surfaces as a 422 with that message.
+  response = client.post(
+    '/signup',
+    json={
+      'name': 'Jo',
+      'username': 'janedoe',
+      'email': 'janedoe@email.com',
+      'password': 'supersecret',
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 422
+  assert response.get_json() == {
+    'error': 'Name must be of type string and more than 3 characters'
+  }


### PR DESCRIPTION
Functional tests for the auth and session endpoints: `/signup`, `/login`, `/logout`, `/check_session`, `/csrf-token`. Covers happy paths plus authentication and validation error cases.

## Coverage
- **csrf-token**: returns a usable, non-empty token.
- **signup**: 201 happy path; 400 empty body; 400 missing fields; 422 duplicate user; 422 invalid name / email / password.
- **login**: 200 valid credentials; 401 wrong password; 401 missing credentials (generic message, no username enumeration).
- **logout**: 200 when logged in; 401 when not.
- **check_session**: 200 authenticated; 401 unauthenticated.

Each test asserts the exact status code and response body from the route source, and checks the password is never returned.

## Test-harness fixes
Two pre-existing bugs in `conftest.py` (from the framework setup) blocked the suite from passing with more than one test. Fixed as separate `fix(tests):` commits:

- **Per-test `g` isolation**: the session-scoped app context leaked Flask's `g` across tests. `flask_wtf.generate_csrf` caches its token in `g` and only writes it to the session when absent, so every test after the first reused a stale token, emitted no session cookie, and failed CSRF on the next mutating request. Fixed with a function-scoped autouse app context.
- **Rate limiter never actually disabled**: Flask-Limiter caches its `enabled` flag at construction time (on `config.py` import), so setting `RATELIMIT_ENABLED` in the fixture was a no-op and signup/login tests hit `429`. Fixed by setting `limiter.enabled = False` directly.

No application code was modified.

## Verification
`PYTHONPATH= pipenv run pytest -q` → 16 passed (15 new + existing smoke). Re-ran to confirm per-test rollback isolation holds.

Closes #14
