### PR TITLE
test: cover pet list and create endpoints

### DIFF
--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -109,3 +109,21 @@ def test_create_pet_unknown_species_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'species of pet does not exist'}
+
+
+def test_create_pet_unknown_symptom_returns_400(auth_client, csrf_token, species):
+  # The species exists so the route reaches symptom resolution, where an unknown
+  # symptom name fails the request before any pet row is created.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'dog',
+      'symptoms': ['nonexistent'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert 'symptom' in response.get_json()['error']

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -37,3 +37,15 @@ def test_create_pet_happy_path_returns_200(auth_client, csrf_token, species, sym
   assert body['species_id'] == species.id
   symptom_names = [s['name'] for s in body['symptoms']]
   assert 'coughing' in symptom_names
+
+
+def test_create_pet_missing_body_returns_400(auth_client, csrf_token):
+  # An empty JSON object is falsy, so the route short-circuits with its own
+  # "info missing" 400 before any species or symptom lookup.
+  response = auth_client.post(
+    '/user/pets',
+    json={},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'User pet info missing'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -127,3 +127,20 @@ def test_create_pet_unknown_symptom_returns_400(auth_client, csrf_token, species
   )
   assert response.status_code == 400
   assert 'symptom' in response.get_json()['error']
+
+
+def test_create_pet_unauthenticated_returns_401(client, csrf_token):
+  # A valid CSRF token clears the global CSRF check, so the request reaches the
+  # default-deny auth hook, which rejects it for having no logged-in session.
+  response = client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'dog',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 401

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -49,3 +49,15 @@ def test_create_pet_missing_body_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'User pet info missing'}
+
+
+def test_create_pet_missing_species_type_returns_400(auth_client, csrf_token):
+  # Without a `type` the route cannot resolve a species, so it rejects before
+  # touching the database.
+  response = auth_client.post(
+    '/user/pets',
+    json={'name': 'Buddy', 'age': 2, 'weight': 10, 'symptoms': ['coughing']},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'species type is missing'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -14,3 +14,26 @@ def test_list_pets_unauthenticated_returns_401(client):
   # the list endpoint must reject the request rather than leak any pets.
   response = client.get('/user/pets')
   assert response.status_code == 401
+
+
+def test_create_pet_happy_path_returns_200(auth_client, csrf_token, species, symptom):
+  # A complete body with a known species type and known symptom names creates the
+  # pet, attaches its symptoms, and echoes the serialized pet back. CSRFProtect is
+  # global so the mutating request must carry the X-CSRFToken header.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'dog',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['name'] == 'Buddy'
+  assert body['species_id'] == species.id
+  symptom_names = [s['name'] for s in body['symptoms']]
+  assert 'coughing' in symptom_names

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -1,0 +1,9 @@
+def test_list_pets_returns_only_current_users_pets(auth_client, pet, other_pet):
+  # The list is scoped to the logged-in user, so test_user sees only their own
+  # pet and never other_user's pet.
+  response = auth_client.get('/user/pets')
+  assert response.status_code == 200
+  body = response.get_json()
+  ids = [p['id'] for p in body]
+  assert pet.id in ids
+  assert other_pet.id not in ids

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -73,3 +73,21 @@ def test_create_pet_missing_symptoms_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'symptoms are missing'}
+
+
+def test_create_pet_duplicate_name_returns_409(auth_client, csrf_token, pet, symptom):
+  # Name uniqueness is scoped to the account. The `pet` fixture already owns a pet
+  # named "Rex" for test_user, so reusing that name is a conflict.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Rex',
+      'age': 1,
+      'weight': 5,
+      'type': 'dog',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 409
+  assert response.get_json() == {'error': 'Pet already Exist'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -4,7 +4,7 @@ def test_list_pets_returns_only_current_users_pets(auth_client, pet, other_pet):
   response = auth_client.get('/user/pets')
   assert response.status_code == 200
   body = response.get_json()
-  ids = [p['id'] for p in body]
+  ids = [returned_pet['id'] for returned_pet in body]
   assert pet.id in ids
   assert other_pet.id not in ids
 
@@ -35,7 +35,7 @@ def test_create_pet_happy_path_returns_200(auth_client, csrf_token, species, sym
   body = response.get_json()
   assert body['name'] == 'Buddy'
   assert body['species_id'] == species.id
-  symptom_names = [s['name'] for s in body['symptoms']]
+  symptom_names = [returned_symptom['name'] for returned_symptom in body['symptoms']]
   assert 'coughing' in symptom_names
 
 

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -7,3 +7,10 @@ def test_list_pets_returns_only_current_users_pets(auth_client, pet, other_pet):
   ids = [p['id'] for p in body]
   assert pet.id in ids
   assert other_pet.id not in ids
+
+
+def test_list_pets_unauthenticated_returns_401(client):
+  # The before_request auth hook is default-deny: without a logged-in session
+  # the list endpoint must reject the request rather than leak any pets.
+  response = client.get('/user/pets')
+  assert response.status_code == 401

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -61,3 +61,15 @@ def test_create_pet_missing_species_type_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'species type is missing'}
+
+
+def test_create_pet_missing_symptoms_returns_400(auth_client, csrf_token):
+  # Symptoms are required: a body with a type but no symptoms is rejected before
+  # the duplicate-name and species lookups.
+  response = auth_client.post(
+    '/user/pets',
+    json={'name': 'Buddy', 'age': 2, 'weight': 10, 'type': 'dog'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'symptoms are missing'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -91,3 +91,21 @@ def test_create_pet_duplicate_name_returns_409(auth_client, csrf_token, pet, sym
   )
   assert response.status_code == 409
   assert response.get_json() == {'error': 'Pet already Exist'}
+
+
+def test_create_pet_unknown_species_returns_400(auth_client, csrf_token):
+  # A `type` that maps to no species row is rejected. No species fixture is needed
+  # precisely because the lookup must fail.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'unicorn',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'species of pet does not exist'}


### PR DESCRIPTION
Covers the pet list and create endpoints in tests/test_pets.py: listing returns only the current user's pets, plus the create happy path and its validation and error cases (missing body, missing fields, unknown references, duplicate name, and unauthenticated). This locks in the expected behavior and authorization for listing and creating pets so regressions in those paths are caught.

Part of #15