### PR TITLE
test: cover pet view, update, and delete endpoints

### DIFF
--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -63,3 +63,14 @@ def test_update_pet_not_found_returns_404(auth_client, csrf_token):
   )
   assert response.status_code == 404
   assert response.get_json() == {'error': 'Pet does not exist'}
+
+
+def test_update_pet_owned_by_another_user_returns_403(auth_client, csrf_token, other_pet):
+  # Ownership is enforced on update: test_user cannot modify other_user's pet.
+  response = auth_client.patch(
+    f'/user/pets/{other_pet.id}',
+    json={'name': 'Hijacked'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -97,3 +97,13 @@ def test_delete_pet_not_found_returns_404(auth_client, csrf_token):
   )
   assert response.status_code == 404
   assert response.get_json() == {'error': 'Pet does not exist'}
+
+
+def test_delete_pet_owned_by_another_user_returns_403(auth_client, csrf_token, other_pet):
+  # Ownership is enforced on delete: test_user cannot delete other_user's pet.
+  response = auth_client.delete(
+    f'/user/pets/{other_pet.id}',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -87,3 +87,13 @@ def test_delete_pet_happy_path_returns_200(auth_client, csrf_token, pet):
   assert response.status_code == 200
   follow_up = auth_client.get(f'/user/pets/{pet_id}')
   assert follow_up.status_code == 404
+
+
+def test_delete_pet_not_found_returns_404(auth_client, csrf_token):
+  # Deleting a non-existent pet returns 404.
+  response = auth_client.delete(
+    '/user/pets/999999',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'Pet does not exist'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -27,3 +27,28 @@ def test_view_pet_unauthenticated_returns_401(client, pet):
   # pet exists.
   response = client.get(f'/user/pets/{pet.id}')
   assert response.status_code == 401
+
+
+def test_update_pet_happy_path_returns_200(auth_client, csrf_token, pet):
+  # Only name/age/weight are updatable. The request also tries to reassign user_id
+  # and species_id, which the model whitelist must ignore to block mass-assignment.
+  original_user_id = pet.user_id
+  original_species_id = pet.species_id
+  response = auth_client.patch(
+    f'/user/pets/{pet.id}',
+    json={
+      'name': 'Rexy',
+      'age': 4,
+      'weight': 25,
+      'user_id': 999,
+      'species_id': 999,
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['name'] == 'Rexy'
+  assert body['age'] == 4
+  assert body['weight'] == 25
+  assert body['user_id'] == original_user_id
+  assert body['species_id'] == original_species_id

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -20,3 +20,10 @@ def test_view_pet_owned_by_another_user_returns_403(auth_client, other_pet):
   response = auth_client.get(f'/user/pets/{other_pet.id}')
   assert response.status_code == 403
   assert response.get_json() == {'error': 'Unauthorized'}
+
+
+def test_view_pet_unauthenticated_returns_401(client, pet):
+  # The default-deny auth hook rejects an unauthenticated read even though the
+  # pet exists.
+  response = client.get(f'/user/pets/{pet.id}')
+  assert response.status_code == 401

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -1,0 +1,7 @@
+def test_view_pet_happy_path_returns_200(auth_client, pet):
+  # The owner can fetch their own pet by id and gets the serialized pet back.
+  response = auth_client.get(f'/user/pets/{pet.id}')
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['id'] == pet.id
+  assert body['name'] == 'Rex'

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -12,3 +12,11 @@ def test_view_pet_not_found_returns_404(auth_client):
   response = auth_client.get('/user/pets/999999')
   assert response.status_code == 404
   assert response.get_json() == {'error': 'Pet does not exist'}
+
+
+def test_view_pet_owned_by_another_user_returns_403(auth_client, other_pet):
+  # The pet exists but belongs to other_user, so test_user is forbidden from
+  # viewing it.
+  response = auth_client.get(f'/user/pets/{other_pet.id}')
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -74,3 +74,16 @@ def test_update_pet_owned_by_another_user_returns_403(auth_client, csrf_token, o
   )
   assert response.status_code == 403
   assert response.get_json() == {'error': 'Unauthorized'}
+
+
+def test_delete_pet_happy_path_returns_200(auth_client, csrf_token, pet):
+  # The owner can delete their own pet; the row is gone afterward, so a follow-up
+  # read returns 404.
+  pet_id = pet.id
+  response = auth_client.delete(
+    f'/user/pets/{pet_id}',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  follow_up = auth_client.get(f'/user/pets/{pet_id}')
+  assert follow_up.status_code == 404

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -52,3 +52,14 @@ def test_update_pet_happy_path_returns_200(auth_client, csrf_token, pet):
   assert body['weight'] == 25
   assert body['user_id'] == original_user_id
   assert body['species_id'] == original_species_id
+
+
+def test_update_pet_not_found_returns_404(auth_client, csrf_token):
+  # Patching a non-existent pet returns 404 before any field is touched.
+  response = auth_client.patch(
+    '/user/pets/999999',
+    json={'name': 'Ghost'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'Pet does not exist'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -5,3 +5,10 @@ def test_view_pet_happy_path_returns_200(auth_client, pet):
   body = response.get_json()
   assert body['id'] == pet.id
   assert body['name'] == 'Rex'
+
+
+def test_view_pet_not_found_returns_404(auth_client):
+  # An id that maps to no pet row returns 404 before any ownership check.
+  response = auth_client.get('/user/pets/999999')
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'Pet does not exist'}


### PR DESCRIPTION
Covers the pet view, update, and delete endpoints in tests/test_pet_by_id.py: the happy paths plus not-found, cross-owner forbidden, and unauthenticated cases. This verifies per-pet access control so one user cannot view, update, or delete another user's pet.

Part of #15