### PR TITLE
test: add functional tests for pet endpoints

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,11 @@ from config import app as flask_app, db, limiter
 # every route, and installs the auth before_request hook and CSRF error handler.
 import app as _app_module
 
+# Model classes referenced by the fixtures below. The app import above already
+# registered them on db.metadata; this only binds the names into this module's
+# namespace so the fixtures can reference them directly.
+from models.models import Pet, Species, Symptom, User
+
 # Single source of truth for the test login. test_user inserts this user and
 # auth_client logs in with these same credentials. Keeping them here avoids
 # duplicating the literals across fixtures where a typo would silently break login.
@@ -102,8 +107,6 @@ def client(app):
 
 @pytest.fixture(scope='function')
 def test_user(db_session):
-  from models.models import User
-
   user = User(
     name='John Smith',
     username=TEST_USERNAME,
@@ -136,8 +139,6 @@ def species(db_session):
   # A single species row used to back pet fixtures and create requests. The
   # type_name is lowercase because the create-pet route lowercases the incoming
   # `type` before looking the species up.
-  from models.models import Species
-
   return Species.create_row(type_name='dog')
 
 
@@ -145,8 +146,6 @@ def species(db_session):
 def symptom(db_session):
   # A single symptom row used to attach to pets and to resolve symptom names in
   # create-pet requests.
-  from models.models import Symptom
-
   return Symptom.create_row(name='coughing')
 
 
@@ -154,8 +153,6 @@ def symptom(db_session):
 def pet(db_session, test_user, species):
   # A pet owned by test_user, so auth_client (logged in as test_user) is its
   # owner. create_row takes the species and user as IDs.
-  from models.models import Pet
-
   return Pet.create_row(
     name='Rex', age=3, weight=20, species=species.id, user=test_user.id
   )
@@ -166,8 +163,6 @@ def other_user(db_session):
   # A second distinct user, used to assert ownership: auth_client is logged in as
   # test_user, so acting on this user's pet must be rejected. Built with the same
   # password-hash setter pattern as test_user.
-  from models.models import User
-
   user = User(
     name='Jane Doe',
     username='janedoe',
@@ -183,8 +178,6 @@ def other_user(db_session):
 def other_pet(db_session, other_user, species):
   # A pet owned by other_user. auth_client (test_user) acting on this pet
   # exercises the 403 ownership path.
-  from models.models import Pet
-
   return Pet.create_row(
     name='Spot', age=5, weight=15, species=species.id, user=other_user.id
   )

--- a/conftest.py
+++ b/conftest.py
@@ -177,3 +177,14 @@ def other_user(db_session):
   db_session.add(user)
   db_session.commit()
   return user
+
+
+@pytest.fixture(scope='function')
+def other_pet(db_session, other_user, species):
+  # A pet owned by other_user. auth_client (test_user) acting on this pet
+  # exercises the 403 ownership path.
+  from models.models import Pet
+
+  return Pet.create_row(
+    name='Spot', age=5, weight=15, species=species.id, user=other_user.id
+  )

--- a/conftest.py
+++ b/conftest.py
@@ -129,3 +129,13 @@ def auth_client(client, test_user, csrf_token):
     headers={'X-CSRFToken': csrf_token},
   )
   return client
+
+
+@pytest.fixture(scope='function')
+def species(db_session):
+  # A single species row used to back pet fixtures and create requests. The
+  # type_name is lowercase because the create-pet route lowercases the incoming
+  # `type` before looking the species up.
+  from models.models import Species
+
+  return Species.create_row(type_name='dog')

--- a/conftest.py
+++ b/conftest.py
@@ -148,3 +148,14 @@ def symptom(db_session):
   from models.models import Symptom
 
   return Symptom.create_row(name='coughing')
+
+
+@pytest.fixture(scope='function')
+def pet(db_session, test_user, species):
+  # A pet owned by test_user, so auth_client (logged in as test_user) is its
+  # owner. create_row takes the species and user as IDs.
+  from models.models import Pet
+
+  return Pet.create_row(
+    name='Rex', age=3, weight=20, species=species.id, user=test_user.id
+  )

--- a/conftest.py
+++ b/conftest.py
@@ -159,3 +159,21 @@ def pet(db_session, test_user, species):
   return Pet.create_row(
     name='Rex', age=3, weight=20, species=species.id, user=test_user.id
   )
+
+
+@pytest.fixture(scope='function')
+def other_user(db_session):
+  # A second distinct user, used to assert ownership: auth_client is logged in as
+  # test_user, so acting on this user's pet must be rejected. Built with the same
+  # password-hash setter pattern as test_user.
+  from models.models import User
+
+  user = User(
+    name='Jane Doe',
+    username='janedoe',
+    email='janedoe@email.com',
+  )
+  user.password_hash = 'otherpassword123'
+  db_session.add(user)
+  db_session.commit()
+  return user

--- a/conftest.py
+++ b/conftest.py
@@ -139,3 +139,12 @@ def species(db_session):
   from models.models import Species
 
   return Species.create_row(type_name='dog')
+
+
+@pytest.fixture(scope='function')
+def symptom(db_session):
+  # A single symptom row used to attach to pets and to resolve symptom names in
+  # create-pet requests.
+  from models.models import Symptom
+
+  return Symptom.create_row(name='coughing')

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -63,3 +63,14 @@ def test_update_pet_not_found_returns_404(auth_client, csrf_token):
   )
   assert response.status_code == 404
   assert response.get_json() == {'error': 'Pet does not exist'}
+
+
+def test_update_pet_owned_by_another_user_returns_403(auth_client, csrf_token, other_pet):
+  # Ownership is enforced on update: test_user cannot modify other_user's pet.
+  response = auth_client.patch(
+    f'/user/pets/{other_pet.id}',
+    json={'name': 'Hijacked'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -97,3 +97,13 @@ def test_delete_pet_not_found_returns_404(auth_client, csrf_token):
   )
   assert response.status_code == 404
   assert response.get_json() == {'error': 'Pet does not exist'}
+
+
+def test_delete_pet_owned_by_another_user_returns_403(auth_client, csrf_token, other_pet):
+  # Ownership is enforced on delete: test_user cannot delete other_user's pet.
+  response = auth_client.delete(
+    f'/user/pets/{other_pet.id}',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -87,3 +87,13 @@ def test_delete_pet_happy_path_returns_200(auth_client, csrf_token, pet):
   assert response.status_code == 200
   follow_up = auth_client.get(f'/user/pets/{pet_id}')
   assert follow_up.status_code == 404
+
+
+def test_delete_pet_not_found_returns_404(auth_client, csrf_token):
+  # Deleting a non-existent pet returns 404.
+  response = auth_client.delete(
+    '/user/pets/999999',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'Pet does not exist'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -27,3 +27,28 @@ def test_view_pet_unauthenticated_returns_401(client, pet):
   # pet exists.
   response = client.get(f'/user/pets/{pet.id}')
   assert response.status_code == 401
+
+
+def test_update_pet_happy_path_returns_200(auth_client, csrf_token, pet):
+  # Only name/age/weight are updatable. The request also tries to reassign user_id
+  # and species_id, which the model whitelist must ignore to block mass-assignment.
+  original_user_id = pet.user_id
+  original_species_id = pet.species_id
+  response = auth_client.patch(
+    f'/user/pets/{pet.id}',
+    json={
+      'name': 'Rexy',
+      'age': 4,
+      'weight': 25,
+      'user_id': 999,
+      'species_id': 999,
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['name'] == 'Rexy'
+  assert body['age'] == 4
+  assert body['weight'] == 25
+  assert body['user_id'] == original_user_id
+  assert body['species_id'] == original_species_id

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -20,3 +20,10 @@ def test_view_pet_owned_by_another_user_returns_403(auth_client, other_pet):
   response = auth_client.get(f'/user/pets/{other_pet.id}')
   assert response.status_code == 403
   assert response.get_json() == {'error': 'Unauthorized'}
+
+
+def test_view_pet_unauthenticated_returns_401(client, pet):
+  # The default-deny auth hook rejects an unauthenticated read even though the
+  # pet exists.
+  response = client.get(f'/user/pets/{pet.id}')
+  assert response.status_code == 401

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -1,0 +1,7 @@
+def test_view_pet_happy_path_returns_200(auth_client, pet):
+  # The owner can fetch their own pet by id and gets the serialized pet back.
+  response = auth_client.get(f'/user/pets/{pet.id}')
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['id'] == pet.id
+  assert body['name'] == 'Rex'

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -12,3 +12,11 @@ def test_view_pet_not_found_returns_404(auth_client):
   response = auth_client.get('/user/pets/999999')
   assert response.status_code == 404
   assert response.get_json() == {'error': 'Pet does not exist'}
+
+
+def test_view_pet_owned_by_another_user_returns_403(auth_client, other_pet):
+  # The pet exists but belongs to other_user, so test_user is forbidden from
+  # viewing it.
+  response = auth_client.get(f'/user/pets/{other_pet.id}')
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -74,3 +74,16 @@ def test_update_pet_owned_by_another_user_returns_403(auth_client, csrf_token, o
   )
   assert response.status_code == 403
   assert response.get_json() == {'error': 'Unauthorized'}
+
+
+def test_delete_pet_happy_path_returns_200(auth_client, csrf_token, pet):
+  # The owner can delete their own pet; the row is gone afterward, so a follow-up
+  # read returns 404.
+  pet_id = pet.id
+  response = auth_client.delete(
+    f'/user/pets/{pet_id}',
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  follow_up = auth_client.get(f'/user/pets/{pet_id}')
+  assert follow_up.status_code == 404

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -52,3 +52,14 @@ def test_update_pet_happy_path_returns_200(auth_client, csrf_token, pet):
   assert body['weight'] == 25
   assert body['user_id'] == original_user_id
   assert body['species_id'] == original_species_id
+
+
+def test_update_pet_not_found_returns_404(auth_client, csrf_token):
+  # Patching a non-existent pet returns 404 before any field is touched.
+  response = auth_client.patch(
+    '/user/pets/999999',
+    json={'name': 'Ghost'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'Pet does not exist'}

--- a/tests/test_pet_by_id.py
+++ b/tests/test_pet_by_id.py
@@ -5,3 +5,10 @@ def test_view_pet_happy_path_returns_200(auth_client, pet):
   body = response.get_json()
   assert body['id'] == pet.id
   assert body['name'] == 'Rex'
+
+
+def test_view_pet_not_found_returns_404(auth_client):
+  # An id that maps to no pet row returns 404 before any ownership check.
+  response = auth_client.get('/user/pets/999999')
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'Pet does not exist'}

--- a/tests/test_pet_results.py
+++ b/tests/test_pet_results.py
@@ -42,3 +42,18 @@ def test_pet_results_owned_by_another_user_returns_403(auth_client, other_pet):
   response = auth_client.get(f'/user/pets/{other_pet.id}/results')
   assert response.status_code == 403
   assert response.get_json() == {'error': 'Unauthorized'}
+
+
+def test_pet_results_no_matching_illnesses_returns_404(
+  auth_client, db_session, pet, species
+):
+  # The pet's species needs a classification so the lookup does not crash, but the
+  # pet has no symptoms, so no illness matches and the endpoint reports 404.
+  from models.models import Classification, SpeciesClassification
+
+  classification = Classification.create_row(classification='mammal')
+  SpeciesClassification.create(species=species, classification=classification)
+
+  response = auth_client.get(f'/user/pets/{pet.id}/results')
+  assert response.status_code == 404
+  assert response.get_json() == {'error': 'No Results found'}

--- a/tests/test_pet_results.py
+++ b/tests/test_pet_results.py
@@ -57,3 +57,10 @@ def test_pet_results_no_matching_illnesses_returns_404(
   response = auth_client.get(f'/user/pets/{pet.id}/results')
   assert response.status_code == 404
   assert response.get_json() == {'error': 'No Results found'}
+
+
+def test_pet_results_unauthenticated_returns_401(client, pet):
+  # The default-deny auth hook blocks the results endpoint for an unauthenticated
+  # session even though the pet exists.
+  response = client.get(f'/user/pets/{pet.id}/results')
+  assert response.status_code == 401

--- a/tests/test_pet_results.py
+++ b/tests/test_pet_results.py
@@ -1,18 +1,19 @@
+from models.models import (
+  Classification,
+  Illness,
+  IllnessClassification,
+  IllnessSymptom,
+  PetSymptom,
+  SpeciesClassification,
+)
+
+
 def test_pet_results_happy_path_returns_200(
   auth_client, db_session, pet, species, symptom
 ):
   # The results endpoint walks a full chain: the pet's symptom -> illnesses with
   # that symptom, intersected with illnesses whose classification matches the
   # pet's species classification. Build that chain so a matching illness exists.
-  from models.models import (
-    Illness,
-    IllnessSymptom,
-    Classification,
-    SpeciesClassification,
-    IllnessClassification,
-    PetSymptom,
-  )
-
   PetSymptom.create_row(pet=pet, symptom=symptom)
   illness = Illness.create_row(
     name='Kennel Cough', description='A respiratory infection', remedy='Rest'
@@ -49,8 +50,6 @@ def test_pet_results_no_matching_illnesses_returns_404(
 ):
   # The pet's species needs a classification so the lookup does not crash, but the
   # pet has no symptoms, so no illness matches and the endpoint reports 404.
-  from models.models import Classification, SpeciesClassification
-
   classification = Classification.create_row(classification='mammal')
   SpeciesClassification.create(species=species, classification=classification)
 

--- a/tests/test_pet_results.py
+++ b/tests/test_pet_results.py
@@ -26,3 +26,11 @@ def test_pet_results_happy_path_returns_200(
   assert response.status_code == 200
   names = [illness['name'] for illness in response.get_json()]
   assert 'Kennel Cough' in names
+
+
+def test_pet_results_pet_not_found_returns_400(auth_client):
+  # The results endpoint reports a missing pet with 400 (not 404, unlike the other
+  # pet-by-id routes), short-circuiting before any classification lookup.
+  response = auth_client.get('/user/pets/999999/results')
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'pet id not found or pet does not exist'}

--- a/tests/test_pet_results.py
+++ b/tests/test_pet_results.py
@@ -1,0 +1,28 @@
+def test_pet_results_happy_path_returns_200(
+  auth_client, db_session, pet, species, symptom
+):
+  # The results endpoint walks a full chain: the pet's symptom -> illnesses with
+  # that symptom, intersected with illnesses whose classification matches the
+  # pet's species classification. Build that chain so a matching illness exists.
+  from models.models import (
+    Illness,
+    IllnessSymptom,
+    Classification,
+    SpeciesClassification,
+    IllnessClassification,
+    PetSymptom,
+  )
+
+  PetSymptom.create_row(pet=pet, symptom=symptom)
+  illness = Illness.create_row(
+    name='Kennel Cough', description='A respiratory infection', remedy='Rest'
+  )
+  IllnessSymptom.create_row(illness=illness, symptom=symptom)
+  classification = Classification.create_row(classification='mammal')
+  SpeciesClassification.create(species=species, classification=classification)
+  IllnessClassification.create_row(illness=illness, classification=classification)
+
+  response = auth_client.get(f'/user/pets/{pet.id}/results')
+  assert response.status_code == 200
+  names = [illness['name'] for illness in response.get_json()]
+  assert 'Kennel Cough' in names

--- a/tests/test_pet_results.py
+++ b/tests/test_pet_results.py
@@ -34,3 +34,11 @@ def test_pet_results_pet_not_found_returns_400(auth_client):
   response = auth_client.get('/user/pets/999999/results')
   assert response.status_code == 400
   assert response.get_json() == {'error': 'pet id not found or pet does not exist'}
+
+
+def test_pet_results_owned_by_another_user_returns_403(auth_client, other_pet):
+  # The ownership check runs before any classification work, so requesting another
+  # user's pet results is forbidden.
+  response = auth_client.get(f'/user/pets/{other_pet.id}/results')
+  assert response.status_code == 403
+  assert response.get_json() == {'error': 'Unauthorized'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -109,3 +109,21 @@ def test_create_pet_unknown_species_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'species of pet does not exist'}
+
+
+def test_create_pet_unknown_symptom_returns_400(auth_client, csrf_token, species):
+  # The species exists so the route reaches symptom resolution, where an unknown
+  # symptom name fails the request before any pet row is created.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'dog',
+      'symptoms': ['nonexistent'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert 'symptom' in response.get_json()['error']

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -37,3 +37,15 @@ def test_create_pet_happy_path_returns_200(auth_client, csrf_token, species, sym
   assert body['species_id'] == species.id
   symptom_names = [s['name'] for s in body['symptoms']]
   assert 'coughing' in symptom_names
+
+
+def test_create_pet_missing_body_returns_400(auth_client, csrf_token):
+  # An empty JSON object is falsy, so the route short-circuits with its own
+  # "info missing" 400 before any species or symptom lookup.
+  response = auth_client.post(
+    '/user/pets',
+    json={},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'User pet info missing'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -127,3 +127,20 @@ def test_create_pet_unknown_symptom_returns_400(auth_client, csrf_token, species
   )
   assert response.status_code == 400
   assert 'symptom' in response.get_json()['error']
+
+
+def test_create_pet_unauthenticated_returns_401(client, csrf_token):
+  # A valid CSRF token clears the global CSRF check, so the request reaches the
+  # default-deny auth hook, which rejects it for having no logged-in session.
+  response = client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'dog',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 401

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -49,3 +49,15 @@ def test_create_pet_missing_body_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'User pet info missing'}
+
+
+def test_create_pet_missing_species_type_returns_400(auth_client, csrf_token):
+  # Without a `type` the route cannot resolve a species, so it rejects before
+  # touching the database.
+  response = auth_client.post(
+    '/user/pets',
+    json={'name': 'Buddy', 'age': 2, 'weight': 10, 'symptoms': ['coughing']},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'species type is missing'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -14,3 +14,26 @@ def test_list_pets_unauthenticated_returns_401(client):
   # the list endpoint must reject the request rather than leak any pets.
   response = client.get('/user/pets')
   assert response.status_code == 401
+
+
+def test_create_pet_happy_path_returns_200(auth_client, csrf_token, species, symptom):
+  # A complete body with a known species type and known symptom names creates the
+  # pet, attaches its symptoms, and echoes the serialized pet back. CSRFProtect is
+  # global so the mutating request must carry the X-CSRFToken header.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'dog',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 200
+  body = response.get_json()
+  assert body['name'] == 'Buddy'
+  assert body['species_id'] == species.id
+  symptom_names = [s['name'] for s in body['symptoms']]
+  assert 'coughing' in symptom_names

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -1,0 +1,9 @@
+def test_list_pets_returns_only_current_users_pets(auth_client, pet, other_pet):
+  # The list is scoped to the logged-in user, so test_user sees only their own
+  # pet and never other_user's pet.
+  response = auth_client.get('/user/pets')
+  assert response.status_code == 200
+  body = response.get_json()
+  ids = [p['id'] for p in body]
+  assert pet.id in ids
+  assert other_pet.id not in ids

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -73,3 +73,21 @@ def test_create_pet_missing_symptoms_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'symptoms are missing'}
+
+
+def test_create_pet_duplicate_name_returns_409(auth_client, csrf_token, pet, symptom):
+  # Name uniqueness is scoped to the account. The `pet` fixture already owns a pet
+  # named "Rex" for test_user, so reusing that name is a conflict.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Rex',
+      'age': 1,
+      'weight': 5,
+      'type': 'dog',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 409
+  assert response.get_json() == {'error': 'Pet already Exist'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -4,7 +4,7 @@ def test_list_pets_returns_only_current_users_pets(auth_client, pet, other_pet):
   response = auth_client.get('/user/pets')
   assert response.status_code == 200
   body = response.get_json()
-  ids = [p['id'] for p in body]
+  ids = [returned_pet['id'] for returned_pet in body]
   assert pet.id in ids
   assert other_pet.id not in ids
 
@@ -35,7 +35,7 @@ def test_create_pet_happy_path_returns_200(auth_client, csrf_token, species, sym
   body = response.get_json()
   assert body['name'] == 'Buddy'
   assert body['species_id'] == species.id
-  symptom_names = [s['name'] for s in body['symptoms']]
+  symptom_names = [returned_symptom['name'] for returned_symptom in body['symptoms']]
   assert 'coughing' in symptom_names
 
 

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -7,3 +7,10 @@ def test_list_pets_returns_only_current_users_pets(auth_client, pet, other_pet):
   ids = [p['id'] for p in body]
   assert pet.id in ids
   assert other_pet.id not in ids
+
+
+def test_list_pets_unauthenticated_returns_401(client):
+  # The before_request auth hook is default-deny: without a logged-in session
+  # the list endpoint must reject the request rather than leak any pets.
+  response = client.get('/user/pets')
+  assert response.status_code == 401

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -61,3 +61,15 @@ def test_create_pet_missing_species_type_returns_400(auth_client, csrf_token):
   )
   assert response.status_code == 400
   assert response.get_json() == {'error': 'species type is missing'}
+
+
+def test_create_pet_missing_symptoms_returns_400(auth_client, csrf_token):
+  # Symptoms are required: a body with a type but no symptoms is rejected before
+  # the duplicate-name and species lookups.
+  response = auth_client.post(
+    '/user/pets',
+    json={'name': 'Buddy', 'age': 2, 'weight': 10, 'type': 'dog'},
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'symptoms are missing'}

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -91,3 +91,21 @@ def test_create_pet_duplicate_name_returns_409(auth_client, csrf_token, pet, sym
   )
   assert response.status_code == 409
   assert response.get_json() == {'error': 'Pet already Exist'}
+
+
+def test_create_pet_unknown_species_returns_400(auth_client, csrf_token):
+  # A `type` that maps to no species row is rejected. No species fixture is needed
+  # precisely because the lookup must fail.
+  response = auth_client.post(
+    '/user/pets',
+    json={
+      'name': 'Buddy',
+      'age': 2,
+      'weight': 10,
+      'type': 'unicorn',
+      'symptoms': ['coughing'],
+    },
+    headers={'X-CSRFToken': csrf_token},
+  )
+  assert response.status_code == 400
+  assert response.get_json() == {'error': 'species of pet does not exist'}


### PR DESCRIPTION
Functional tests for the pet endpoints: list, create, view, update, delete, and results. Covers happy paths plus ownership/authorization, not-found, and validation error cases. Aggregates the per-endpoint work merged via #26, #27, #28, and #29.

## Coverage
- **shared fixtures**: pet, species, and symptom fixtures added to `conftest.py` for reuse across the pet suites.
- **list**: authenticated owner sees only their pets; unauthenticated returns 401.
- **create**: 201 happy path; duplicate name 409; unknown species 400; unknown symptom 400; unauthenticated 401.
- **view / update / delete**: happy paths plus cross-owner forbidden, not-found, and unauthenticated cases.
- **results**: 200 with matching illness chain; pet-not-found 400; cross-owner 403; no-matching-illnesses 404; unauthenticated 401.

Each test asserts the exact status code and response body from the route source and enforces ownership and authentication.

## Verification
`PYTHONPATH= pipenv run pytest -q` passes locally.

Closes #15